### PR TITLE
THORN-1531: Following instructions at wildfly-swarm-example/ribbon-co…

### DIFF
--- a/ribbon-consul/README.md
+++ b/ribbon-consul/README.md
@@ -12,10 +12,11 @@ To execute this test, you must
 
 You can run consul with
 
-    consul agent -dev
+    $ consul agent -dev
 
-Once the above is satisfied, you can run
-
-    mvn verify -Pconsul -Dswarm.consul.url=http://<IP>:<PORT>
-
-
+ Once the above is satisfied, you can run the examples with:
+ 
+     $ mvn wildfly-swarm:run -Dswarm.bind.address=127.0.0.1 -Dswarm.consul.url=http://<IP>:<PORT> -Dswarm.port.offset=<OFFSET>
+ 
+ You need to supply a bind address since wildfly-swarm will bind to "0.0.0.0" by default, which consul doesn't accept as service endpoint.
+ If you have consul running on localhost you can leave out the `swarm.consul.url`.

--- a/ribbon-consul/events/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/events/TimeService.java
+++ b/ribbon-consul/events/src/main/java/org/wildfly/swarm/examples/netflix/ribbon/events/TimeService.java
@@ -11,7 +11,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * @author Bob McWhirter
  */
-@ResourceGroup( name="time" )
+@ResourceGroup( name="example-ribbon-consul-time" )
 public interface TimeService {
 
     TimeService INSTANCE = Ribbon.from(TimeService.class);


### PR DESCRIPTION
…nsul doesn't yield desirable result.

Motivation
----------
If you follow the instructions on the ribbon consul examples it won't work because topology connector will try to advertise 0.0.0.0: to consul - which is invalid. You need to supply a valid ip address for swarm.bind.address - that should be mentioned in the readme.
Also the examples still use Main class which is deprecated..

Modifications
-------------
Changed the readme to reflect the necessary command line parameter.

Result
------
Examples will be better understandable and runnable by newcomers.

NOTE:
This is a repeat of https://github.com/thorntail/thorntail-examples/pull/155 based on the current master.