### PR TITLE
THORN-2168: the "uberjar" profile in Examples no longer works

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
     <profile>
       <id>uberjar</id>
       <properties>
-        <thorntail.useUberJar>true</thorntail.useUberJar>
+        <wildfly-swarm.useUberJar>true</wildfly-swarm.useUberJar>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Motivation
----------
As part of the rename from WildFly Swarm to Thorntail, the `uberjar`
profile in Examples was changed to set the `thorntail.useUberJar`
property instead of `wildfly-swarm.useUberJar`. That change was
wrong. To keep backwards compabitility, we still use the old name
`wildfly-swarm.useUberJar`.

Modifications
-------------
Restore the original property name.

Result
------
The `uberjar` profile works again.