### PR TITLE
Update Gradle multi-module project example.

### DIFF
--- a/gradle-examples/README.md
+++ b/gradle-examples/README.md
@@ -14,6 +14,10 @@ The following are examples of multi-module Gradle projects that showcase buildin
 
 * [CDI + JAXRS + Swagger](multi-module)
 
+> NOTE: The multi-module example showcases leveraging the upcoming Gradle 5 preview-feature of importing dependency
+>  constraints from Maven BOMs, i.e., 
+> [IMPROVED_POM_SUPPORT](https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:bom_import)
+
 ## Developer Notes
 
 ### Updating the Gradle version.

--- a/gradle-examples/jaxrs-cdi/settings.gradle
+++ b/gradle-examples/jaxrs-cdi/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'thorntail-rest-app'
+rootProject.name = 'example-gradle'

--- a/gradle-examples/multi-module/build.gradle
+++ b/gradle-examples/multi-module/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     }
 
     dependencies {
-        classpath "io.spring.gradle:dependency-management-plugin:1.0.3.RELEASE"
         classpath("io.thorntail:thorntail-gradle-plugin:$version") {
             if (version.endsWith('-SNAPSHOT')) {
                 changing = true
@@ -17,8 +16,6 @@ buildscript {
 }
 
 subprojects {
-    // Apply the dependency management plugin to all projects.
-    apply plugin: "io.spring.dependency-management"
     apply plugin: "java"
 
     // Configure the repositories for all projects.
@@ -36,19 +33,20 @@ subprojects {
 
     version = System.getProperty('swarmVersion') ?: '2.3.0.Final-SNAPSHOT'
 
-    // Assuming that all our modules might require one or more dependencies from the Thorntail BOM.
-    dependencyManagement {
-        imports {
-            mavenBom "io.thorntail:bom-all:$version"
-        }
-    }
     dependencies {
         // Include the JavaEE API dependency.
         compileOnly 'javax:javaee-api:7.0'
         testCompileOnly 'javax:javaee-api:7.0'
+        
+        // Include the Thorntail BOM for testing the code.
+        testImplementation ("io.thorntail:bom-all:$version") {
+            if (version.endsWith('-SNAPSHOT')) {
+                changing = true
+            }
+        }
 
-        testCompile "junit:junit:4.12"
-        testCompile("io.thorntail:gradle-arquillian-adapter:$version") {
+        testImplementation "junit:junit:4.12"
+        testImplementation("io.thorntail:gradle-arquillian-adapter:$version") {
             if (version.endsWith('-SNAPSHOT')) {
                 changing = true
             }

--- a/gradle-examples/multi-module/library-module/build.gradle
+++ b/gradle-examples/multi-module/library-module/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    testRuntime "io.thorntail:cdi"
+    testImplementation 'io.thorntail:cdi'
 }

--- a/gradle-examples/multi-module/settings.gradle
+++ b/gradle-examples/multi-module/settings.gradle
@@ -1,5 +1,5 @@
 // Turn on Gradle 5 feature
-// enableFeaturePreview('IMPROVED_POM_SUPPORT')
+enableFeaturePreview('IMPROVED_POM_SUPPORT')
 
 rootProject.name = 'thorntail-multi-module-app'
 include 'library-module', 'web-app'

--- a/gradle-examples/multi-module/web-app/build.gradle
+++ b/gradle-examples/multi-module/web-app/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'war'
 
 dependencies {
     compile project(':library-module')
-    testCompile "commons-io:commons-io:2.4"
-    testCompile "io.thorntail:cdi"
-    testCompile "io.thorntail:jaxrs"
+    testImplementation 'commons-io:commons-io:2.4'
+    testImplementation 'io.thorntail:cdi'
+    testImplementation 'io.thorntail:jaxrs'
     
     // Additional fractions to include.
     // providedRuntime "io.thorntail:swagger"


### PR DESCRIPTION
* Showcase compatibility of Gradle 5 preview feature around improved Maven BOM dependency constraints.
* Verify that the latest Gradle Arquillian adapter changes are working as expected.