### PR TITLE
[Gradle Examples] Instructions for enabling the JaCoCo agent for Arquillian based tests

### DIFF
--- a/gradle-examples/multi-module/build.gradle
+++ b/gradle-examples/multi-module/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    version = System.getProperty('swarmVersion') ?: '2.3.0.Final-SNAPSHOT'
+    version = System.getProperty('swarmVersion') ?: VERSION_THORNTAIL
 
     repositories {
         mavenLocal()
@@ -16,7 +16,8 @@ buildscript {
 }
 
 subprojects {
-    apply plugin: "java"
+    apply plugin: 'java'
+    apply plugin: 'jacoco'
 
     // Configure the repositories for all projects.
     repositories {
@@ -31,15 +32,15 @@ subprojects {
         }
     }
 
-    version = System.getProperty('swarmVersion') ?: '2.3.0.Final-SNAPSHOT'
+    version = System.getProperty('swarmVersion') ?: VERSION_THORNTAIL
 
     dependencies {
         // Include the JavaEE API dependency.
         compileOnly 'javax:javaee-api:7.0'
         testCompileOnly 'javax:javaee-api:7.0'
-        
+
         // Include the Thorntail BOM for testing the code.
-        testImplementation ("io.thorntail:bom-all:$version") {
+        testImplementation("io.thorntail:bom-all:$version") {
             if (version.endsWith('-SNAPSHOT')) {
                 changing = true
             }
@@ -52,7 +53,26 @@ subprojects {
             }
         }
         // Make use of the tooling jar appropriate for the current Gradle version.
-        testCompile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
+        testImplementation "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
+
+        // Include the Arquillian JaCoCo extension
+        testImplementation 'org.jboss.arquillian.extension:arquillian-jacoco:1.0.0.Alpha9'
+
+    }
+
+    // Configure the properties required for enabling the JaCoCo agent withing Arquillian tests
+    test {
+
+        doFirst {
+            // Gradle starts the test task with the JaCoCo agent configured.
+            // The Arquillian tests are run in a separate thread which does not have the JaCoCo agent enabled.
+            // In the below code, we retrieve the JaCoCo details and make it available as a system property that is
+            // consumed by the "arquillian.xml" file in the "test/resources" folder.
+            String arg = jacoco.asJvmArg
+            String dir = project.buildDir
+            arg = arg.replaceAll(project.relativePath(dir), dir)
+            systemProperty 'thorntail.arquillian.jvm.args', arg
+        }
     }
 
     // Optional configuration

--- a/gradle-examples/multi-module/gradle.properties
+++ b/gradle-examples/multi-module/gradle.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 Red Hat, Inc, and individual contributors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+VERSION_THORNTAIL=2.2.1.Final

--- a/gradle-examples/multi-module/library-module/src/test/resources/arquillian.xml
+++ b/gradle-examples/multi-module/library-module/src/test/resources/arquillian.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc, and individual contributors.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="daemon" default="true">
+        <configuration>
+            <property name="host">localhost</property>
+            <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
+            <property name="javaVmArguments">${thorntail.arquillian.jvm.args:}</property>
+        </configuration>
+    </container>
+    <extension qualifier="jacoco">
+        <property name="includes">org.*</property>
+    </extension>
+</arquillian>

--- a/gradle-examples/multi-module/web-app/src/test/java/org/wildfly/swarm/examples/gradle/ArqWarDeploymentTest.java
+++ b/gradle-examples/multi-module/web-app/src/test/java/org/wildfly/swarm/examples/gradle/ArqWarDeploymentTest.java
@@ -6,7 +6,9 @@ import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -21,6 +23,9 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Arquillian.class)
 public class ArqWarDeploymentTest {
+
+    @ArquillianResource
+    private URL url;
 
     /**
      * Build the archive for testing.
@@ -45,8 +50,10 @@ public class ArqWarDeploymentTest {
      * Verify that we are able to make use of the RunAsClient annotation as well.
      */
     @Test
+    @RunAsClient
     public void testAPIInvocation() throws IOException {
-        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/api/"), Charset.forName("UTF-8").toString());
+        URL endPoint = new URL(url.getProtocol(), url.getHost(), url.getPort(), "/api");
+        String content = IOUtils.toString(endPoint, Charset.forName("UTF-8").toString());
         assertTrue("Did not receive the appropriate content.", content.contains("hello: Thorntail + gradle + java"));
     }
 

--- a/gradle-examples/multi-module/web-app/src/test/resources/arquillian.xml
+++ b/gradle-examples/multi-module/web-app/src/test/resources/arquillian.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc, and individual contributors.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="daemon" default="true">
+        <configuration>
+            <property name="host">localhost</property>
+            <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
+            <property name="javaVmArguments">${thorntail.arquillian.jvm.args:}</property>
+        </configuration>
+    </container>
+    <extension qualifier="jacoco">
+        <property name="includes">org.*</property>
+    </extension>
+</arquillian>


### PR DESCRIPTION
* Updated the README with instructions.
* Configured JaCoCo on the multi-module project.