### PR TITLE
Corrected capitalization that prevented maven dependencies from working when copied from MDs

### DIFF
--- a/flyway/README.md
+++ b/flyway/README.md
@@ -17,7 +17,7 @@ The project adds a `<plugin>` to configure `thorntail-maven-plugin` to
 create the runnable `.jar`.
 
     <plugin>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>thorntail-maven-plugin</artifactId>
       <version>${version.thorntail}</version>
       <executions>
@@ -32,7 +32,7 @@ create the runnable `.jar`.
 To define the needed parts of Thorntail, a dependency is added
 
     <dependency>
-        <groupid>io.thorntail</groupId>
+        <groupId>io.thorntail</groupId>
         <artifactId>flyway</artifactId>
         <version>${version.thorntail}</version>
     </dependency>

--- a/jsf/README.md
+++ b/jsf/README.md
@@ -18,7 +18,7 @@ create the runnable `.jar`.
 
 ``` xml
 <plugin>
-  <groupid>io.thorntail</groupId>
+  <groupId>io.thorntail</groupId>
   <artifactId>thorntail-maven-plugin</artifactId>
   <version>${version.thorntail}</version>
   <executions>
@@ -35,12 +35,12 @@ To define the needed parts of Thorntail, a dependency is added
 
 ``` xml
 <dependency>
-  <groupid>io.thorntail</groupId>
+  <groupId>io.thorntail</groupId>
   <artifactId>jsf</artifactId>
   <version>${version.thorntail}</version>
 </dependency>
 <dependency>
-  <groupid>io.thorntail</groupId>
+  <groupId>io.thorntail</groupId>
   <artifactId>cdi</artifactId>
   <version>${version.thorntail}</version>
 </dependency>

--- a/kitchensink-html5-mobile/README.md
+++ b/kitchensink-html5-mobile/README.md
@@ -17,7 +17,7 @@ The project adds a `<plugin>` to configure `thorntail-maven-plugin` to
 create the runnable `.jar`.
 
     <plugin>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>thorntail-maven-plugin</artifactId>
       <version>${version.thorntail}</version>
       <executions>
@@ -32,22 +32,22 @@ create the runnable `.jar`.
 To define the needed parts of Thorntail, the following dependencies are added
 
     <dependency>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>jaxrs-weld</artifactId>
       <version>${version.thorntail}</version>
     </dependency>
     <dependency>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>jpa</artifactId>
       <version>${version.thorntail}</version>
     </dependency>
     <dependency>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>ejb</artifactId>
       <version>${version.thorntail}</version>
     </dependency>
     <dependency>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>hibernate-validator</artifactId>
       <version>${version.thorntail}</version>
     </dependency>

--- a/microprofile/README.md
+++ b/microprofile/README.md
@@ -17,7 +17,7 @@ The project adds a `<plugin>` to configure `thorntail-maven-plugin` to
 create the runnable `.jar`.
 
     <plugin>
-      <groupid>io.thorntail</groupId>
+      <groupId>io.thorntail</groupId>
       <artifactId>thorntail-maven-plugin</artifactId>
       <version>${version.thorntail}</version>
       <executions>
@@ -32,7 +32,7 @@ create the runnable `.jar`.
 To define the needed parts of Thorntail, a dependency is added
 
     <dependency>
-        <groupid>io.thorntail</groupId>
+        <groupId>io.thorntail</groupId>
         <artifactId>microprofile</artifactId>
         <version>${version.thorntail}</version>
     </dependency>


### PR DESCRIPTION
Corrected capitalization that prevented maven dependencies from working, in many cases the opening tag <groupId> was spelled <groupid> conflicting with closing tag.