### PR TITLE
Adding hollow JAR example

### DIFF
--- a/docker/docker-jaxrs-hollow/Dockerfile
+++ b/docker/docker-jaxrs-hollow/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:jre-alpine
+
+ADD hollow-jar/target/example-docker-jaxrs-hollow-hollow-thorntail.jar /opt/hollow-thorntail.jar
+ADD application/target/example-docker-jaxrs-hollow-application.war /opt/application.war
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/opt/hollow-thorntail.jar", "-Djava.net.preferIPv4Stack=true", "/opt/application.war"]

--- a/docker/docker-jaxrs-hollow/README.adoc
+++ b/docker/docker-jaxrs-hollow/README.adoc
@@ -1,0 +1,62 @@
+= Thorntail Docker image using a hollow JAR
+
+This example shows how to build a Thorntail application in form of a https://docs.thorntail.io/2.3.0.Final/#hollow-jar_thorntail[hollow JAR].
+Instead of building one single _uberjar_, a hollow JAR contains only the runtime components but not your actual application itself.
+This plays nicely together with layered container images: unless your application's dependencies change
+(e.g. because you're using one more of the Java EE APIs which means that another Thorntail fraction must be added to the hollow JAR),
+only the image layer with the thin application WAR must be re-built.
+This is very efficient in terms of build time and distributing the image.
+
+== Build the hollow JAR
+
+Run `mvn clean install -pl hollow-jar`.
+A _example-docker-jaxrs-hollow-hollow-thorntail.jar_ file will be built in the _hollow-jar/target_ folder.
+
+== Build the application WAR
+
+Run `mvn clean install -pl application`.
+A _example-docker-jaxrs-hollow-application.war_ file will be built in the _application/target_ folder.
+
+== Build the container image containing a Thorntail microservice
+
+Build the container image by running `docker build -t example-docker-jaxrs-hollow-jar`.
+You then can run the Docker container and start the Thorntail microservice (a simple JAX-RS application) with the following commands:
+
+`docker run -p 8080:8080 example-docker-jaxrs-hollow-jar`
+
+== Inspect your running Docker containers
+
+From a terminal run `docker ps` and you should see something like:
+
+    CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS              PORTS                    NAMES
+    a840d7990c15        example-docker-jaxrs-hollow-jar           "/bin/sh -c 'java -ja"   43 seconds ago      Up 42 seconds       0.0.0.0:8080->8080/tcp   admiring_brattain
+
+Now try to `curl` the resource running inside Docker:
+
+    curl localhost:8080/resource
+
+Result should be the following:
+
+    bar
+
+== Inspect the image history
+
+From a terminal run `docker image history example-docker-jaxrs-hollow-jar` and you should see something like:
+
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    49e3ad5e5d35        8 seconds ago       /bin/sh -c #(nop)  ENTRYPOINT ["java" "-jar"…   0B
+    626845640c85        8 seconds ago       /bin/sh -c #(nop)  EXPOSE 8080                  0B
+    fe6ebf276aaf        8 seconds ago       /bin/sh -c #(nop) ADD file:15d156433fec71f2b…   3.9kB
+    9e52594ce062        15 minutes ago      /bin/sh -c #(nop) ADD file:e2d445038c831f006…   72MB
+    ccfb0c83b2fe        7 months ago        /bin/sh -c set -x  && apk add --no-cache   o…   78.6MB
+    <missing>           7 months ago        /bin/sh -c #(nop)  ENV JAVA_ALPINE_VERSION=8…   0B
+    <missing>           7 months ago        /bin/sh -c #(nop)  ENV JAVA_VERSION=8u171       0B
+    <missing>           7 months ago        /bin/sh -c #(nop)  ENV PATH=/usr/local/sbin:…   0B
+    <missing>           7 months ago        /bin/sh -c #(nop)  ENV JAVA_HOME=/usr/lib/jv…   0B
+    <missing>           7 months ago        /bin/sh -c {   echo '#!/bin/sh';   echo 'set…   87B
+    <missing>           7 months ago        /bin/sh -c #(nop)  ENV LANG=C.UTF-8             0B
+    <missing>           7 months ago        /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
+    <missing>           7 months ago        /bin/sh -c #(nop) ADD file:25f61d70254b9807a…   4.41MB
+
+Note how only the layers fe6ebf276aaf (containing the application WAR) and derived ones are re-built if the hollow JAR remains unchanged,
+whereas the layer 9e52594ce062 (containing the hollow JAR) didn't get re-built.

--- a/docker/docker-jaxrs-hollow/application/pom.xml
+++ b/docker/docker-jaxrs-hollow/application/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>example-docker-jaxrs-hollow-parent</artifactId>
+    <groupId>io.thorntail.examples</groupId>
+    <version>2.3.1.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>example-docker-jaxrs-hollow-application</artifactId>
+
+  <name>Thorntail Examples: Docker and JAX-RS with Hollow JAR (Application)</name>
+  <description>Thorntail Examples: JAX-RS in Docker container with Hollow JAR (Application)</description>
+  <packaging>war</packaging>
+
+  <properties>
+      <failOnMissingWebXml>false</failOnMissingWebXml>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>7.0</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+</project>
+

--- a/docker/docker-jaxrs-hollow/application/src/main/java/org/wildfly/swarm/example/docker/JaxRsApplication.java
+++ b/docker/docker-jaxrs-hollow/application/src/main/java/org/wildfly/swarm/example/docker/JaxRsApplication.java
@@ -1,0 +1,19 @@
+package org.wildfly.swarm.example.docker;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+@ApplicationPath("/")
+public class JaxRsApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(MyResource.class);
+        return classes;
+    }
+}

--- a/docker/docker-jaxrs-hollow/application/src/main/java/org/wildfly/swarm/example/docker/MyResource.java
+++ b/docker/docker-jaxrs-hollow/application/src/main/java/org/wildfly/swarm/example/docker/MyResource.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.example.docker;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/resource")
+public class MyResource {
+
+    @GET
+    @Produces("text/plain")
+    public String foo() {
+        return "bar\n";
+    }
+}

--- a/docker/docker-jaxrs-hollow/hollow-jar/pom.xml
+++ b/docker/docker-jaxrs-hollow/hollow-jar/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>example-docker-jaxrs-hollow-parent</artifactId>
+    <groupId>io.thorntail.examples</groupId>
+    <version>2.3.1.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>example-docker-jaxrs-hollow-hollow-jar</artifactId>
+
+  <name>Thorntail Examples: Docker and JAX-RS with Hollow JAR (Hollow JAR)</name>
+  <description>Thorntail Examples: JAX-RS in Docker container with Hollow JAR (Hollow JAR)</description>
+  <packaging>war</packaging>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+	<dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>cdi</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>example-docker-jaxrs-hollow</finalName>
+    <plugins>
+      <plugin>
+        <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-maven-plugin</artifactId>
+        <configuration>
+          <hollow>true</hollow>
+        </configuration>
+        <executions>
+          <execution>
+            <id>package</id>
+          </execution>
+          <execution>
+            <id>start</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/docker/docker-jaxrs-hollow/pom.xml
+++ b/docker/docker-jaxrs-hollow/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>examples-docker</artifactId>
+    <groupId>io.thorntail.examples</groupId>
+    <version>2.3.1.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>example-docker-jaxrs-hollow-parent</artifactId>
+
+  <name>Thorntail Examples: Docker and JAX-RS with Hollow JAR</name>
+  <description>Thorntail Examples: JAX-RS in Docker container with Hollow JAR</description>
+  <packaging>pom</packaging>
+
+  <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+   <build>
+  </build>
+
+  <modules>
+    <module>application</module>
+    <module>hollow-jar</module>
+  </modules>
+</project>


### PR DESCRIPTION
Hey @kenfinnigan et al., this adds an example for using a hollow JAR in a layered Docker image, avoiding repeated invocations of the Thorntail plug-in and recreation of large image layers with the uberjar, provided the application's dependencies haven't changed.