### PR TITLE
THORN-2332 Artemis cluster doesn't form in messaging-clustering QS

### DIFF
--- a/messaging/messaging-clustering/src/main/resources/project-defaults.yaml
+++ b/messaging/messaging-clustering/src/main/resources/project-defaults.yaml
@@ -16,10 +16,10 @@ swarm:
         cluster-password: CHANGEME
         discovery-groups:
           activemq-discovery:
-            jgroups-channel: activemq-jgroups-channel
+            jgroups-cluster: activemq-cluster
         broadcast-groups:
           activemq-broadcast:
-            jgroups-channel: activemq-jgroups-broadcast
+            jgroups-cluster: activemq-cluster
             connectors:
               - http-connector
         cluster-connections:


### PR DESCRIPTION
https://issues.jboss.org/browse/THORN-2332

* Discovery and broadcast cluster names has to match, otherwise discovery won't receive messages from broadcast.
* `jgroups-channel` seems to be just renamed to `jgroups-cluster` attribute in Wildfly [1], so `channel` seems to be kind of deprecated, although documentation doesn't mention that.

[1] https://github.com/wildfly/wildfly/blob/master/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java#L75