### PR TITLE
THORN-2310 Add snapshot repository to gradle examples

### DIFF
--- a/gradle-examples/ejb-jaxrs-mail/build.gradle
+++ b/gradle-examples/ejb-jaxrs-mail/build.gradle
@@ -4,6 +4,9 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
   }
 
   dependencies {
@@ -29,6 +32,9 @@ run {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
 }
 
 dependencies {

--- a/gradle-examples/jaxrs-cdi/build.gradle
+++ b/gradle-examples/jaxrs-cdi/build.gradle
@@ -4,6 +4,9 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
   }
 
   dependencies {
@@ -34,6 +37,9 @@ repositories {
   }
   maven {
     url "https://repo.gradle.org/gradle/libs-releases-local"
+  }
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots/"
   }
 }
 

--- a/gradle-examples/jpa-jaxrs-cdi/build.gradle
+++ b/gradle-examples/jpa-jaxrs-cdi/build.gradle
@@ -4,6 +4,9 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+      url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
   }
 
   dependencies {
@@ -31,6 +34,9 @@ repositories {
   }
   maven {
     url "https://repo.gradle.org/gradle/libs-releases-local"
+  }
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots/"
   }
 }
 

--- a/gradle-examples/multi-module/build.gradle
+++ b/gradle-examples/multi-module/build.gradle
@@ -4,6 +4,9 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 
     dependencies {
@@ -34,6 +37,9 @@ subprojects {
         maven {
             name 'Gradle Tooling'
             url 'https://repo.gradle.org/gradle/libs-releases/'
+        }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
     }
 


### PR DESCRIPTION
...so that tt-examples master branch builds without having to install current
tt master locally.

https://issues.jboss.org/browse/THORN-2310