### PR TITLE
THORN-2391: Unable to build thorntail-examples with different value for version.thorntail.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>io.thorntail</groupId>
       <artifactId>arquillian</artifactId>
-      <version>${project.version}</version>
+      <version>${version.thorntail}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -222,7 +222,7 @@
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>bom-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.thorntail}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
THORN-2391: Unable to build thorntail-examples with different value for version.thorntail.

Motivation
----------
Parent pom.xml contains wrong version references for two dependencies (io.thorntail:arquillian and io.thorntail:bom-all).

Modifications
-------------
Made changes in https://github.com/thorntail/thorntail-examples/blob/master/pom.xml lines #204, #225 replace with '<version>${version.thorntail}</version>'.

Result
------
Will result in better developers experience.