### PR TITLE
THORN-2419: remove wildfly-swarm.useUberJar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
     <profile>
       <id>uberjar</id>
       <properties>
-        <wildfly-swarm.useUberJar>true</wildfly-swarm.useUberJar>
+        <thorntail.useUberJar>true</thorntail.useUberJar>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Motivation
----------
In https://github.com/thorntail/thorntail/pull/1299, we removed
the `wildfly-swarm.useUberJar` system property. Examples need
to follow suit.

Modifications
-------------
Use `thorntail.useUberJar` instead of `wildfly-swarm.useUberJar`.

Result
------
Uberjar examples will work with upcoming Thorntail release.